### PR TITLE
Respect custom system prompt

### DIFF
--- a/mistral_conversation/__init__.py
+++ b/mistral_conversation/__init__.py
@@ -42,6 +42,7 @@ from .const import (
     RECOMMENDED_REASONING_EFFORT,
     RECOMMENDED_TEMPERATURE,
     RECOMMENDED_TOP_P,
+    DEFAULT_SYSTEM_PROMPT,
 )
 
 SERVICE_GENERATE_IMAGE = "generate_image"
@@ -83,10 +84,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         api_key: str = entry.data.get(CONF_API_KEY)
         client = MistralClient(api_key, get_async_client(hass))
 
-        prompt = call.data[CONF_PROMPT]
+        user_prompt = call.data[CONF_PROMPT]
+        system_prompt = entry.options.get(CONF_PROMPT, DEFAULT_SYSTEM_PROMPT)
         messages = [
-            {"role": "system", "content": "You are a Home Assistant smart home AI. Only respond with Home Assistant compatible commands."},
-            {"role": "user", "content": prompt},
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
         ]
         payload = {
             "model": model,

--- a/mistral_conversation/const.py
+++ b/mistral_conversation/const.py
@@ -20,6 +20,9 @@ RECOMMENDED_MAX_TOKENS = 150
 RECOMMENDED_REASONING_EFFORT = "low"
 RECOMMENDED_TEMPERATURE = 1.0
 RECOMMENDED_TOP_P = 1.0
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a Home Assistant smart home AI. Only respond with Home Assistant compatible commands."
+)
 
 # Mistral unterstützt keine Websuche, daher deaktiviert
 CONF_WEB_SEARCH = "web_search"

--- a/mistral_conversation/conversation.py
+++ b/mistral_conversation/conversation.py
@@ -26,6 +26,7 @@ from .const import (
     RECOMMENDED_REASONING_EFFORT,
     RECOMMENDED_TEMPERATURE,
     RECOMMENDED_TOP_P,
+    DEFAULT_SYSTEM_PROMPT,
 )
 
 MAX_TOOL_ITERATIONS = 3
@@ -106,7 +107,7 @@ class MistralConversationEntity(
                 DOMAIN,
                 user_input,
                 options.get(CONF_LLM_HASS_API),
-                options.get(CONF_PROMPT),
+                options.get(CONF_PROMPT, DEFAULT_SYSTEM_PROMPT),
             )
         except conversation.ConverseError as err:
             return err.as_conversation_result()
@@ -130,8 +131,9 @@ class MistralConversationEntity(
     async def _async_handle_chat_log(self, chat_log: conversation.ChatLog) -> None:
         options = self.entry.options
         model = options.get(CONF_CHAT_MODEL, RECOMMENDED_CHAT_MODEL)
+        system_prompt = options.get(CONF_PROMPT, DEFAULT_SYSTEM_PROMPT)
         messages = [
-            {"role": "system", "content": "You are a Home Assistant smart home AI. Only respond with Home Assistant compatible commands."}
+            {"role": "system", "content": system_prompt}
         ]
         for content in chat_log.content:
             messages.extend(_convert_content_to_param(content))


### PR DESCRIPTION
## Summary
- honor the configured system prompt in conversation calls
- expose a shared `DEFAULT_SYSTEM_PROMPT` constant

## Testing
- `pytest`